### PR TITLE
Remove custom protected chest code from bls custom

### DIFF
--- a/item_overrides.lua
+++ b/item_overrides.lua
@@ -164,36 +164,6 @@ if minetest.get_modpath("farming") and farming.mod == "redo" then
     add_groups("ethereal:strawberry", "not_in_creative_inventory")
 end
 
-if minetest.get_modpath("hook") then
-    tubelib.register_node("hook:pchest_node", {}, {
-        on_pull_item = function(pos, side, player_name)
-            local inv = minetest.get_meta(pos):get_inventory()
-            for _, stack in pairs(inv:get_list("main")) do
-                if not stack:is_empty() then
-                    return inv:remove_item("main", stack:get_name())
-                end
-            end
-            return nil
-        end,
-        on_push_item = function(pos, side, item, player_name)
-            local inv = minetest.get_meta(pos):get_inventory()
-            if inv:room_for_item("main", item) then
-                inv:add_item("main", item)
-                return true
-            end
-            return false
-        end,
-        on_unpull_item = function(pos, side, item, player_name)
-            local inv = minetest.get_meta(pos):get_inventory()
-            if inv:room_for_item("main", item) then
-                inv:add_item("main", item)
-                return true
-            end
-            return false
-        end,
-    })
-end
-
 if minetest.global_exists("maptools") then
     -- Prevent super apples from being placed.
     minetest.override_item("maptools:superapple", {


### PR DESCRIPTION
Cleanup for issue 273 https://github.com/BlockySurvival/issue-tracker/issues/273

This is a companion to these changes https://github.com/AiTechEye/hook/pull/6 / https://github.com/fluxionary/hook/pull/2

This MUST be pulled if those changes are pulled

This should be pulled IMMEDIATELY after those changes, or they will not take effect properly

Basically, what has been removed here has been re-established in the hook mod, we should not have both