### PR TITLE
Nerf cobblegen by returning normal stone only

### DIFF
--- a/techpack/quarry.lua
+++ b/techpack/quarry.lua
@@ -4,6 +4,9 @@ local gn = tubelib_addons1.register_ground_node
 
 gn("bls:marble")
 
+-- This one line breaks the cobblegen > autosieve pathway completely
+gn("default:stone","default:stone")
+
 if minetest.get_modpath("building_blocks") then
     gn("building_blocks:Marble")
 end


### PR DESCRIPTION
This nerfs the connection between cobblegens and autosieves, while still returning a useful item that can be used in place of cobble in all non-OP scenarios