### PR TITLE
Extra checks on certain files to stop them erroring

### DIFF
--- a/custom_items/infinity_bracer.lua
+++ b/custom_items/infinity_bracer.lua
@@ -1,3 +1,8 @@
+if not (
+        minetest.get_modpath("3d_armor")
+    and minetest.global_exists("armor")
+) then return end
+
 armor:register_armor("bls:infinity_bracer", {
     description = "Infinity Bracer",
     inventory_image = "bls_infinity_bracer_inv.png",

--- a/custom_items/maptools.lua
+++ b/custom_items/maptools.lua
@@ -1,3 +1,8 @@
+if not (
+        minetest.get_modpath("maptools")
+    and minetest.global_exists("maptools")
+) then return end
+
 minetest.register_node(":maptools:clean_glass", {
         description = "Unbreakable Clean Glass",
         range = 12,

--- a/hunger_overrides.lua
+++ b/hunger_overrides.lua
@@ -222,14 +222,17 @@ if minetest.get_modpath("extra") then
     set_eat("extra:tomato_slice", 0)
 end
 
-if minetest.get_modpath("farming") then
+if minetest.get_modpath("farming") and minetest.global_exists("farming")  then
+
+    set_eat("farming:bread", 4)
+    if farming.mod == "redo" then
+
     set_eat("farming:baked_potato", 4)
     set_eat("farming:beans", 2)
     set_eat("farming:beetroot", 2)
     set_eat("farming:beetroot_soup", 6, bowl) -- TODO make this not just a beet concentrate?
     set_eat("farming:blueberries", 2)
     set_eat("farming:blueberry_pie", 8)
-    set_eat("farming:bread", 4)
     set_eat("farming:bread_multigrain", 8)
     set_eat("farming:bread_slice", 2)
     set_eat("farming:carrot", 2)
@@ -273,6 +276,7 @@ if minetest.get_modpath("farming") then
     set_eat("farming:toast_sandwich", 6)
     set_eat("farming:tomato", 2)
     set_eat("farming:turkish_delight", 12)
+    end
 end
 
 if minetest.get_modpath("homedecor_gastronomy") then


### PR DESCRIPTION
Fixes #10 

- Extra modpath & global checks for armor and maptools
- All farming redo foods dependent on redo mod


This has not been tested with mods enabled, only disabled, as I am not even sure what some of these things do