### PR TITLE
Discard drop and wield/inventory image data when registering mahogany leaves with the cutting saw

### DIFF
--- a/microblocks.lua
+++ b/microblocks.lua
@@ -61,6 +61,8 @@ local function register(recipe_item, make_stairs, make_facade, make_letters)
         -- TODO: figure out a check to see if these are already registered?
         local def_copy = table.copy(def)
         def_copy.drop = nil
+        def_copy.wield_image = nil
+        def_copy.inventory_image = nil
         stairsplus:register_all(modname, subname, recipe_item, def_copy)
     end
 

--- a/microblocks.lua
+++ b/microblocks.lua
@@ -159,7 +159,26 @@ if get_modpath("mahogany") then
     def_copy.drop = nil
     def_copy.wield_image = nil
     def_copy.inventory_image = nil
-    def_copy.after_place_node = nil
+    def_copy.after_place_node = function(pos, placer, itemstack, pointed_thing)
+        if placer and placer:is_player() then
+            local vertical_correction = {
+                [12]=15,
+                [14]=15,
+                [7]=6,
+                [5]=6,
+                [18]=17,
+                [16]=17,
+                [9]=8,
+                [11]=8
+            }
+            local node = minetest.get_node(pos)
+            local correction = vertical_correction[node.param2]
+            if correction then
+                node.param2 = correction
+                minetest.set_node(pos, node)
+            end
+        end
+    end
     stairsplus:register_all("mahogany", "leaves", "mahogany:leaves", def_copy)
 end
 

--- a/microblocks.lua
+++ b/microblocks.lua
@@ -59,11 +59,7 @@ local function register(recipe_item, make_stairs, make_facade, make_letters)
 
     if has_stairsplus and make_stairs then
         -- TODO: figure out a check to see if these are already registered?
-        local def_copy = table.copy(def)
-        def_copy.drop = nil
-        def_copy.wield_image = nil
-        def_copy.inventory_image = nil
-        stairsplus:register_all(modname, subname, recipe_item, def_copy)
+        stairsplus:register_all(modname, subname, recipe_item, def)
     end
 
     if has_facade and make_facade then
@@ -158,7 +154,13 @@ if get_modpath("farming") then
 end
 
 if get_modpath("mahogany") then
-    register("mahogany:leaves", nil, false)
+    local def = registered_nodes["mahogany:leaves"]
+    local def_copy = table.copy(def)
+    def_copy.drop = nil
+    def_copy.wield_image = nil
+    def_copy.inventory_image = nil
+    def_copy.after_place_node = nil
+    stairsplus:register_all("mahogany", "leaves", "mahogany:leaves", def_copy)
 end
 
 if get_modpath("mobs_animal") then

--- a/microblocks.lua
+++ b/microblocks.lua
@@ -59,7 +59,9 @@ local function register(recipe_item, make_stairs, make_facade, make_letters)
 
     if has_stairsplus and make_stairs then
         -- TODO: figure out a check to see if these are already registered?
-        stairsplus:register_all(modname, subname, recipe_item, def)
+        local def_copy = table.copy(def)
+        def_copy.drop = nil
+        stairsplus:register_all(modname, subname, recipe_item, def_copy)
     end
 
     if has_facade and make_facade then


### PR DESCRIPTION
Fixes https://github.com/BlockySurvival/issue-tracker/issues/278
