### PR TITLE
fix cobweb crafting conflict between xdecor and homedecor; add tranformative crafts between them

### DIFF
--- a/crafting_overrides.lua
+++ b/crafting_overrides.lua
@@ -1386,6 +1386,30 @@ if minetest.get_modpath("wool") then
 end
 
 if minetest.get_modpath("xdecor") then
+    minetest.clear_craft({output="xdecor:cobweb"})
+    if minetest.get_modpath("farming") then
+        minetest.register_craft({
+            output = "xdecor:cobweb 5",
+            recipe = {
+                {"",               "farming:string", ""},
+                {"farming:string", "farming:string", "farming:string"},
+                {"",               "farming:string", ""},
+            }
+        })
+        minetest.register_craft({
+            output = "xdecor:cobweb",
+            recipe = {
+                {"homedecor:cobweb_corner"},
+            }
+        })
+        minetest.register_craft({
+            output = "homedecor:cobweb_corner",
+            recipe = {
+                {"xdecor:cobweb"},
+            }
+        })
+    end
+
     if minetest.get_modpath("farming") then
         -- avoid conflict with farming tatami
         minetest.clear_craft({output="xdecor:tatami"})


### PR DESCRIPTION
Fixes https://github.com/BlockySurvival/issue-tracker/issues/298
- Replace X-shaped craft with +-shaped craft for xdecor, leaving the X-shaped craft for homedecor
- Added crafts to swap between xdecor and homedecor cobwebs