### PR TITLE
Fix proportions and swappings for straw crafts

### DIFF
--- a/crafting_overrides.lua
+++ b/crafting_overrides.lua
@@ -297,6 +297,20 @@ if minetest.get_modpath("cottages") then
                 {"cottages:straw_mat"},
             }
         })
+
+        minetest.clear_craft({recipe = {{"farming:straw"}}})
+        minetest.clear_craft({recipe = {{"cottages:straw_bale"}}})
+
+        minetest.register_craft({
+            output = "cottages:straw_bale 2",
+            type = "shapeless",
+            recipe = {"farming:straw"}
+        })
+        minetest.register_craft({
+            output = "farming:straw",
+            type = "shapeless",
+            recipe = {"cottages:straw_bale","cottages:straw_bale"}
+        })
     end
 end
 

--- a/crafting_overrides.lua
+++ b/crafting_overrides.lua
@@ -303,13 +303,21 @@ if minetest.get_modpath("cottages") then
 
         minetest.register_craft({
             output = "cottages:straw_bale 2",
-            type = "shapeless",
-            recipe = {"farming:straw"}
+            recipe = {{"farming:straw"}}
         })
         minetest.register_craft({
             output = "farming:straw",
             type = "shapeless",
             recipe = {"cottages:straw_bale","cottages:straw_bale"}
+        })
+        minetest.register_craft({
+            output = "cottages:straw_mat 3",
+            recipe = {{"cottages:straw_bale"}}
+        })
+        minetest.register_craft({
+            output = "farming:wheat 6",
+            type = "shapeless",
+            recipe = {"farming:straw","farming:straw"}
         })
     end
 end


### PR DESCRIPTION
Fixes https://github.com/BlockySurvival/issue-tracker/issues/299

Replace `straw_bale <=> straw` crafts to fix proportion maths and conflicts between them