### PR TITLE
Stop unexpected swapping of stairs and slabs if the nodes are not from the same mod

### DIFF
--- a/microblocks_cleanup.lua
+++ b/microblocks_cleanup.lua
@@ -254,10 +254,14 @@ for node_id, def in pairs(minetest.registered_nodes) do
 
                 tgt = minetest.registered_aliases[tgt] or tgt
 
-                if tgt and minetest.registered_nodes[tgt] then
+                if tgt and minetest.registered_nodes[tgt] and
+                    (   not minetest.registered_nodes[src] -- Do not swap nodes from other mods that may have been registered with the same name
+                        or minetest.registered_nodes[src].mod_origin == minetest.registered_nodes[tgt].mod_origin
+                    ) then
                     bls.log("action", "registering alias: %q -> %q", src, tgt)
                     table.insert(source_ids, src)
                     target_by_source[src] = {tgt, rot_func}
+
                     --minetest.register_alias_force(src, tgt)
                 else
                     bls.log("warning", "FAILED alias: %q -> %q", src, tgt)

--- a/microblocks_cleanup.lua
+++ b/microblocks_cleanup.lua
@@ -261,7 +261,6 @@ for node_id, def in pairs(minetest.registered_nodes) do
                     bls.log("action", "registering alias: %q -> %q", src, tgt)
                     table.insert(source_ids, src)
                     target_by_source[src] = {tgt, rot_func}
-
                     --minetest.register_alias_force(src, tgt)
                 else
                     bls.log("warning", "FAILED alias: %q -> %q", src, tgt)


### PR DESCRIPTION
Fixes https://github.com/BlockySurvival/issue-tracker/issues/308

Adds a condition to check if nodes to be swapped are from the same mod or not - we should not be swapping nodes from different mods with each other, this causes unexpected behaviour 