### PR TITLE
Add commands to mark self as AFK and check if another player is AFK

### DIFF
--- a/afk_tag.lua
+++ b/afk_tag.lua
@@ -3,7 +3,7 @@ if not minetest.get_modpath("more_monoids") then return end
 bls.afk = {}
 
 local AFK_CHECK_INTERVAL = 15  -- seconds
-local AFK_BOUND_PERIOD = 10 * 1 * 1000000 -- microseconds
+local AFK_BOUND_PERIOD = 10 * 60 * 1000000 -- microseconds
 
 local assertions_by_player = {}
 local last_action_by_player = {}

--- a/afk_tag.lua
+++ b/afk_tag.lua
@@ -137,6 +137,7 @@ minetest.register_chatcommand("afk", {
     func = function(player, reason)
         is_afk(minetest.get_player_by_name(player), time_since_last_action(player))
         assertions_by_player[player] = reason
+        minetest.chat_send_player(player, 'You have been marked as AFK')
     end,
 })
 

--- a/afk_tag.lua
+++ b/afk_tag.lua
@@ -3,25 +3,43 @@ if not minetest.get_modpath("more_monoids") then return end
 bls.afk = {}
 
 local AFK_CHECK_INTERVAL = 15  -- seconds
-local AFK_BOUND_PERIOD = 10 * 60 * 1000000 -- microseconds
+local AFK_BOUND_PERIOD = 10 * 1 * 1000000 -- microseconds
 
+local assertions_by_player = {}
 local last_action_by_player = {}
 local previous_keys_by_player = {}
 local afk_check_elapsed = 0
 
+local function time_since_last_action(player_name)
+    local last_action = last_action_by_player[player_name]
+    if last_action then
+        return minetest.get_us_time() - last_action
+    end
+    return 0
+end
+
+local function is_afk(player, afk_us)
+    local text = minetest.colorize("#FF0000", ("AFK for %im"):format(afk_us / (60 * 1000000)))
+    more_monoids.player_tag:add_change(player, text, "afk")
+end
+
+local function is_not_afk(player)
+    more_monoids.player_tag:del_change(player, "afk")
+    assertions_by_player[player:get_player_name()] = nil
+end
+
 function bls.afk.set_afk(player, afk_us)
-    if afk_us > AFK_BOUND_PERIOD then
-        local text = minetest.colorize("#FF0000", ("AFK for %im"):format(afk_us / (60 * 1000000)))
-        more_monoids.player_tag:add_change(player, text, "afk")
+    if assertions_by_player[player:get_player_name()] or afk_us > AFK_BOUND_PERIOD then
+        is_afk(player, afk_us)
     else
-        more_monoids.player_tag:del_change(player, "afk")
+        is_not_afk(player)
     end
 end
 
 function bls.afk.note_action(player, name)
     name = name or player:get_player_name()
     last_action_by_player[name] = minetest.get_us_time()
-    more_monoids.player_tag:del_change(player, "afk")
+    is_not_afk(player)
 end
 
 -- globalstep to update AFK tag
@@ -76,7 +94,11 @@ minetest.register_on_joinplayer(function(player, last_login)
 end)
 
 minetest.register_on_leaveplayer(function(player, timed_out)
-    if player then last_action_by_player[player:get_player_name()] = nil end
+    if player then
+        local name = player:get_player_name()
+        last_action_by_player[name] = nil
+        assertions_by_player[name] = nil
+    end
 end)
 
 minetest.register_on_chat_message(function(name, message)
@@ -109,3 +131,38 @@ minetest.register_on_item_eat(function(hp_change, replace_with_item, itemstack, 
     if player then bls.afk.note_action(player) end
 end)
 
+minetest.register_chatcommand("afk", {
+    description = "Mark yourself as AFK so other players will know you're not available",
+    params = "(<reason>)",
+    func = function(player, reason)
+        is_afk(minetest.get_player_by_name(player), time_since_last_action(player))
+        assertions_by_player[player] = reason
+    end,
+})
+
+minetest.register_chatcommand("is_afk", {
+    description = "Check if a player has the AFK flag",
+    params = "<player>",
+    func = function(player, given_player_name)
+
+        local target_player = bls.util.get_player_by_name(given_player_name)
+        if not target_player then
+            minetest.chat_send_player(player, ('No player named "%s" is currently logged in'):format(given_player_name))
+            return
+        end
+
+        local cannon_player_name = target_player:get_player_name()
+        local afk_us = time_since_last_action(cannon_player_name)
+        local reason = assertions_by_player[cannon_player_name]
+
+        if reason or afk_us > AFK_BOUND_PERIOD then
+            minetest.chat_send_player(player, ('Player "%s" has been AFK for %im%s'):format(
+                cannon_player_name,
+                afk_us / (60 * 1000000),
+                reason and #reason > 0 and ": "..reason or ""
+            ))
+        else
+            minetest.chat_send_player(player, ('Player "%s" does not seem to be AFK'):format(cannon_player_name))
+        end
+    end,
+})

--- a/util.lua
+++ b/util.lua
@@ -107,10 +107,9 @@ function bls.util.get_player_by_name(given_player_name)
     end
 
     local lower_player_name = clean_player_name:lower()
-    for _, player in ipairs(minetest.get_connected_players()) do
-        local player_name = player:get_player_name()
-        if player_name:lower() == lower_player_name then
-            return minetest.get_player_by_name(player_name)
+    for _, connected_player in ipairs(minetest.get_connected_players()) do
+        if connected_player:get_player_name():lower() == lower_player_name then
+            return connected_player
         end
     end
 end

--- a/util.lua
+++ b/util.lua
@@ -95,3 +95,22 @@ function bls.util.tables_equal(t1, t2, ignore_mt)
     end
     return true
 end
+
+-- Get player by name, case insensitive, cleans whitespace
+function bls.util.get_player_by_name(given_player_name)
+    local found_player = minetest.get_player_by_name(given_player_name)
+    if found_player then return found_player end
+
+    local clean_player_name = given_player_name:gsub("%s+", "")
+    if clean_player_name == "" then
+        return
+    end
+
+    local lower_player_name = clean_player_name:lower()
+    for _, player in ipairs(minetest.get_connected_players()) do
+        local player_name = player:get_player_name()
+        if player_name:lower() == lower_player_name then
+            return minetest.get_player_by_name(player_name)
+        end
+    end
+end


### PR DESCRIPTION
Fixes https://github.com/BlockySurvival/issue-tracker/issues/317

- Adds the ability for players to mark themselves as AFK, giving a reason - this will immediately give them the AFK tag as they have asserted that they are AFK
- Any action will remove their assertion that they are AFK
- Other players can check if a player is AFK using the new `/is_afk` command, this will respond if they have the tag or have otherwise marked themselves AFK, If they have given a reason it will be given in the response
- New util added for getting a player by a user input name 