### PR TITLE
Provide animation frame count for forceload block

### DIFF
--- a/animation_frames.lua
+++ b/animation_frames.lua
@@ -1,0 +1,10 @@
+-- The smartshop manually renders inventorycubes, but we don't have enough information to slice a single frame of animation out, so all frames render simultaneously
+-- We must manually provide the number of frames for any item we wish to render correctly, this is dirty, but it works
+
+
+if minetest.get_modpath("tubelib") then
+	local forceload_animation = minetest.registered_nodes["tubelib:forceload"].tiles[3].animation
+
+	forceload_animation.frames_h = 4
+	forceload_animation.frames_w = 1
+end

--- a/init.lua
+++ b/init.lua
@@ -79,6 +79,7 @@ dofile(bls.modpath .. "/caverealms.lua")
 dofile(bls.modpath .. "/bigdoors/init.lua")
 dofile(bls.modpath .. "/artificial_leather.lua")
 dofile(bls.modpath .. "/plantlife_modpack.lua")
+dofile(bls.modpath .. "/animation_frames.lua")
 
 local http = minetest.request_http_api()
 if http then


### PR DESCRIPTION
Fixes https://github.com/BlockySurvival/issue-tracker/issues/330
In combination with https://github.com/fluxionary/minetest-smartshop/pull/21