### PR TITLE
Reduce errors by updating a few checks

### DIFF
--- a/hunger_overrides.lua
+++ b/hunger_overrides.lua
@@ -339,7 +339,7 @@ if minetest.global_exists("terumet") then
     for item_id, def in pairs(minetest.registered_items) do
         if def._terumet_vacfood then
             local mod, item = item_id:match("terumet:vacf_([^_]+)_(.+)")
-            if mod == "cucina" then
+            if mod == "cucina" or mod == "aqua" then
                 mod, item = item_id:match("terumet:vacf_([^_]+_[^_]+)_(.+)")
             end
             local base_id = ("%s:%s"):format(mod, item)

--- a/microblocks_cleanup.lua
+++ b/microblocks_cleanup.lua
@@ -240,6 +240,7 @@ local variants = {
 
 local source_ids = {}
 local target_by_source = {}
+local existing_aliases = {}
 
 bls.log("action", "registering microblock cleanup")
 
@@ -253,6 +254,10 @@ for node_id, def in pairs(minetest.registered_nodes) do
                 local tgt = nformat(tgt_fmt, {mod_name=mod_name, node_name=node_name})
 
                 tgt = minetest.registered_aliases[tgt] or tgt
+
+                if minetest.registered_aliases[src] == tgt then
+                    existing_aliases[tgt] = src
+                end
 
                 if tgt and minetest.registered_nodes[tgt] and
                     (   not minetest.registered_nodes[src] -- Do not swap nodes from other mods that may have been registered with the same name
@@ -281,7 +286,9 @@ minetest.register_lbm({
         local src = node.name
         local target = target_by_source[src]
         if not target then
-            bls.log("error", "no target for src %q (node %q) @ %s", src, node.name, spos)
+            if not existing_aliases[src] then
+                bls.log("error", "no target for src %q (node %q) @ %s", src, node.name, spos)
+            end
             return
         end
         local tgt, rot = unpack(target)


### PR DESCRIPTION
Fixes https://github.com/BlockySurvival/issue-tracker/issues/331

- Remove ice microblock errors by ignoring the LBM (and the error) for existing aliases
- Remove aqua_farming vacuumed food errors by adding it to the two_part mod names condition